### PR TITLE
Add libgmp-dev to Ubuntu 14-15 dependencies

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -143,7 +143,7 @@ install_os_packages () {
 		;;
 	'linux-ubuntu-14'*|'linux-ubuntu-15'*)
 		sudo bash -c 'apt-get update &&
-			apt-get install -y build-essential git pigz zlib1g-dev' || return 1
+			apt-get install -y build-essential git pigz zlib1g-dev libgmp-dev' || return 1
 		;;
 	'osx-10.7-'*|'osx-10.8-'*)
 		echo '   *** WARNING: Cannot install OS packages' >&2


### PR DESCRIPTION
First I want to thank everyone, including Mietek, who developed this ridiculously awesome Haskell tool.

With the default Docker Ubuntu instances (`docker run -t -i ubuntu:15.04 /bin/bash`), libgmp-dev is not installed by default. This may lead to the GHC compilation error saying

```
/usr/bin/ld: cannot find -lgmp
```

Installing the libgmp-dev package solves this problem immediately.
